### PR TITLE
Only fetch results for partial matches.

### DIFF
--- a/item_input.php
+++ b/item_input.php
@@ -747,15 +747,14 @@ function get_edit_item_instance_form($op, $item_r, $status_type_r, $HTTP_VARS) {
 		}//while
 		db_free_result($results);
 
-		// disable this code until issue #19 is fixed.
-        /*if (get_opendb_config_var('item_input', 'related_item_support') !== FALSE) {
+        if (get_opendb_config_var('item_input', 'related_item_support') !== FALSE) {
             $formContents .= format_field('Parent Item Filter', '<input type="text" name="parent_item_filter" id="parent_item_filter">');
-            $formContents .= format_field('Parent Item', format_item_parents_select($HTTP_VARS, $item_r));
+            $formContents .= format_field('Parent Item', format_item_parents_select($HTTP_VARS, $item_r, '%parent_only%'));
 
             $parent = fetch_item_instance_relationship_r($item_r['item_id'], $item_r['instance_no'], RELATED_PARENTS_MODE);
             $formContents .= format_field('Parent Instance Number', '<input type="text" name="parent_instance_no" onchange="this.value=numericFilter(this.value); return true;" value="' .
                 ($parent['instance_no'] ? $parent['instance_no'] : 1) . '">');
-        }*/
+        }
 
 		$formContents .= "\n</table>";
 

--- a/lib/widgets.php
+++ b/lib/widgets.php
@@ -453,7 +453,7 @@ function get_item_image($s_item_type, $item_id = NULL) {
 }
 
 function format_item_parents_select($HTTP_VARS, $item_r, $filter = null) {
-    $possible_parents = fetch_available_item_parents($HTTP_VARS, $item_r);
+    $possible_parents = fetch_available_item_parents($HTTP_VARS, $item_r, $filter);
 
     $parent_item_list = '<select name="parent_item_id" id="parent_item_id">';
     $parent_item_list .= '<option value="0">None</option>';


### PR DESCRIPTION
This should fix #19 I believe. It should only query the database for the filtered items when searching or just the parent item on initial display.

I've left the option for fetching all items incase it's needed in the future.
