### PR TITLE
Amazon item count fix

### DIFF
--- a/lib/site/amazon.class.php
+++ b/lib/site/amazon.class.php
@@ -75,7 +75,7 @@ class amazon extends SitePlugin {
 
 				//<div class="resultCount">Showing 1 - 12 of 55 Results</div> || class="resultCount">Showing 1 Result</
 				//<span>1-24 von 194 Ergebnissen</span>
-				if ((preg_match("/ id=\"resultCount\">.*?<span>.*?.([0-9]+)[\s]+?-[\s]+?([0-9]+).*?([0-9,]+).*?<\//", $pageBuffer, $regs) || preg_match("/ id=\"resultCount\">.*?<span>.*?.([0-9]+).*?<\//", $pageBuffer, $regs))) {
+				if ((preg_match("/ id=\"resultCount\">.*?<span>.*?.[0-9]+[\s]+?-[\s]+?[0-9]+.*?([0-9,]+).*?<\//", $pageBuffer, $regs) || preg_match("/ id=\"resultCount\">.*?<span>.*?.([0-9]+).*?<\//", $pageBuffer, $regs))) {
 					// need to remove the commas from the total
 					$total = str_replace(",", "", $regs[1]);
 


### PR DESCRIPTION
I was running the Regex that opendb uses for getting item counts from Amazon, and kept getting back incorrect results. It ended up being that some of the wildcards were being allowed to match too much, causing seemingly random numbers from the page to be used for the item count. I've updated the appropriate wildcards to be lazy, allowing the match group to work correctly.
