### PR TITLE
Add database charset setting

### DIFF
--- a/include/local.config.php.dist
+++ b/include/local.config.php.dist
@@ -5,6 +5,7 @@ $CONFIG_VARS['db_server'] = array(
 			'dbname'=>'opendb',		//OpenDb database name
 			'username'=>'lender',	//OpenDb database user name
 			'passwd'=>'test',		//OpenDb user password
+			'charset'=>'utf8',	    //Database charset
 			'table_prefix'=>NULL, 	//'opendb_';//Specify a table prefix.  Include the '_' as well!
 			'debug-sql'=>FALSE);	//Specify whether all SQL statements should be displayed in the page.
 

--- a/include/local.config.php.dist
+++ b/include/local.config.php.dist
@@ -5,7 +5,7 @@ $CONFIG_VARS['db_server'] = array(
 			'dbname'=>'opendb',		//OpenDb database name
 			'username'=>'lender',	//OpenDb database user name
 			'passwd'=>'test',		//OpenDb user password
-			'charset'=>'utf8',	    //Database charset
+			//'charset'=>'utf8',	    //Database charset (OPTIONAL)
 			'table_prefix'=>NULL, 	//'opendb_';//Specify a table prefix.  Include the '_' as well!
 			'debug-sql'=>FALSE);	//Specify whether all SQL statements should be displayed in the page.
 

--- a/lib/database.php
+++ b/lib/database.php
@@ -22,7 +22,7 @@ $_OPENDB_DB_CONNECTED = NULL;
 function init_db_connection() {
 	$dbserver_conf_r = get_opendb_config_var ( 'db_server' );
 	if (is_array ( $dbserver_conf_r )) {
-		return db_connect ( $dbserver_conf_r ['host'], $dbserver_conf_r ['username'], $dbserver_conf_r ['passwd'], $dbserver_conf_r ['dbname'] );
+		return db_connect ( $dbserver_conf_r ['host'], $dbserver_conf_r ['username'], $dbserver_conf_r ['passwd'], $dbserver_conf_r ['dbname'],  $dbserver_conf_r ['charset']);
 	}
 	
 	//else

--- a/lib/database/mysql.inc.php
+++ b/lib/database/mysql.inc.php
@@ -33,7 +33,7 @@ $_opendb_dblink = NULL;
     
     @param $cache_link - if TRUE, save reference to link for reuse.
  */
-function db_connect($host, $user, $passwd, $dbname, $cache_link = TRUE) {
+function db_connect($host, $user, $passwd, $dbname, $charset, $cache_link = TRUE) {
 	global $_opendb_dblink;
 
 	$link = @mysql_connect($host, $user, $passwd);
@@ -42,6 +42,8 @@ function db_connect($host, $user, $passwd, $dbname, $cache_link = TRUE) {
 			if ($cache_link) {
 				$_opendb_dblink = $link;
 			}
+			@mysql_query("SET NAMES '.$charset.'");
+			echo "HOLA";
 			return $link;
 		}
 	}

--- a/lib/database/mysql.inc.php
+++ b/lib/database/mysql.inc.php
@@ -33,7 +33,7 @@ $_opendb_dblink = NULL;
     
     @param $cache_link - if TRUE, save reference to link for reuse.
  */
-function db_connect($host, $user, $passwd, $dbname, $charset, $cache_link = TRUE) {
+function db_connect($host, $user, $passwd, $dbname, $charset = NULL, $cache_link = TRUE) {
 	global $_opendb_dblink;
 
 	$link = @mysql_connect($host, $user, $passwd);
@@ -42,8 +42,7 @@ function db_connect($host, $user, $passwd, $dbname, $charset, $cache_link = TRUE
 			if ($cache_link) {
 				$_opendb_dblink = $link;
 			}
-			@mysql_query("SET NAMES '.$charset.'");
-			echo "HOLA";
+			if ($charset!=NULL) @mysql_query("SET NAMES '.$charset.'");
 			return $link;
 		}
 	}

--- a/lib/database/mysqli.inc.php
+++ b/lib/database/mysqli.inc.php
@@ -35,7 +35,7 @@ $_opendb_dblink = NULL;
     
     @param $cache_link - if TRUE, save reference to link for reuse.
  */
-function db_connect($host, $user, $passwd, $dbname, $charset, $cache_link = TRUE) {
+function db_connect($host, $user, $passwd, $dbname, $charset = NULL, $cache_link = TRUE) {
 	global $_opendb_dblink;
 
 	$index = strpos($host, ':');
@@ -64,7 +64,7 @@ function db_connect($host, $user, $passwd, $dbname, $charset, $cache_link = TRUE
 			$_opendb_dblink = $link;
 		}
 		
-		@mysqli_set_charset($link, $charset);
+		if ($charset!=NULL) @mysqli_set_charset($link, $charset);	
 
 		return $link;
 	}

--- a/lib/database/mysqli.inc.php
+++ b/lib/database/mysqli.inc.php
@@ -35,7 +35,7 @@ $_opendb_dblink = NULL;
     
     @param $cache_link - if TRUE, save reference to link for reuse.
  */
-function db_connect($host, $user, $passwd, $dbname, $cache_link = TRUE) {
+function db_connect($host, $user, $passwd, $dbname, $charset, $cache_link = TRUE) {
 	global $_opendb_dblink;
 
 	$index = strpos($host, ':');
@@ -63,6 +63,8 @@ function db_connect($host, $user, $passwd, $dbname, $cache_link = TRUE) {
 		if ($cache_link) {
 			$_opendb_dblink = $link;
 		}
+		
+		@mysqli_set_charset($link, $charset);
 
 		return $link;
 	}


### PR DESCRIPTION
Using opendb I had problems with accented characters. The issue has been fixed forcing the charset in the database connection to 'utf8' (but it can be changed from the config file). 

Hope you find it useful (but probably you won't need it)

Anyway, thank you for your great job developing OpenDB :-)